### PR TITLE
Send mode and setpoint as separate service calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ It creates a virtual `climate` entity that wraps an existing minisplit `climate`
 an external temperature sensor, watches the sensor, and flips the minisplit between heat and
 cool to hold the room inside the band.
 
-Built for a Tosot/Gree minisplit driven over IR by ESPHome (`heatpumpir`/`greeyac`), where the
-underlying entity is optimistic - commands are fire-and-forget with no confirmation. The
-control logic never trusts the minisplit's reported state or its internal sensor.
+Works with any single-setpoint `climate` entity - a wifi integration like `gree`, or a
+minisplit driven over IR by ESPHome (`heatpumpir`/`greeyac`). The control logic never trusts
+the minisplit's reported state or its internal sensor, so an optimistic fire-and-forget IR
+entity is fine.
 
 ## What you get
 
@@ -54,6 +55,7 @@ restart, and the mode-change cooldown keeps running across an edit.
 | `overshoot` | 0.0 | Pulls the commanded setpoint toward the middle of the band to buy coast time. |
 | `sensor_timeout` | 15 min | How long the sensor may go quiet before the thermostat stops commanding. |
 | `resend_interval` | 0 | Re-send the current command this often, to recover from dropped IR frames. 0 disables it. |
+| `single_command` | off | Send a mode change as one `set_temperature` call carrying `hvac_mode`. Only for ESPHome. See below. |
 
 ## How it decides
 
@@ -88,8 +90,24 @@ modes continuously. A warning is logged when that happens.
 ### One command per change
 
 The thermostat tracks what it last sent and only calls a service when the mode or the setpoint
-actually changes. A mode change and its setpoint go out as a single `climate.set_temperature`
-call carrying `hvac_mode`, which ESPHome turns into one IR frame rather than two.
+actually changes.
+
+A mode change goes out as two service calls: `climate.set_temperature` for the setpoint, then
+`climate.set_hvac_mode`. Setpoint-only changes are a single call.
+
+Two calls rather than one is deliberate. Home Assistant lets you pass `hvac_mode` to
+`climate.set_temperature`, but core does **not** dispatch `async_set_hvac_mode` for you - it
+forwards the kwarg and leaves each platform to handle it, and most don't. Only 29 of the 108
+climate platforms in core even reference it. On the other 79 a combined call would set the
+temperature and silently ignore the mode, so the unit would never start heating or cooling.
+
+The setpoint is sent first on purpose. A unit briefly left in the old mode at the new setpoint
+just idles, whereas the old setpoint under the new mode would run the wrong direction until
+the second call lands.
+
+Set `single_command` to fold a mode change back into one call. ESPHome does honour `hvac_mode`
+inside `set_temperature` and turns it into a single IR frame, so if that's your setup this
+halves the IR traffic and the beeping. Leave it off for anything else.
 
 ## Attributes
 
@@ -143,4 +161,5 @@ python3 -m venv .venv && .venv/bin/pip install -r requirements-dev.txt
 ```
 
 The test suite covers each of the design's acceptance criteria against a mock minisplit that
-behaves like the ESPHome climate entity.
+ignores `hvac_mode` inside `set_temperature`, like most real integrations. A second mock
+models the ESPHome behaviour and covers the `single_command` path.

--- a/custom_components/range_thermostat/climate.py
+++ b/custom_components/range_thermostat/climate.py
@@ -68,6 +68,7 @@ from .const import (
     CONF_RESEND_INTERVAL,
     CONF_SENSOR_ENTITY,
     CONF_SENSOR_TIMEOUT,
+    CONF_SINGLE_COMMAND,
     DEFAULT_BAND_CELSIUS,
     DEFAULT_BAND_FAHRENHEIT,
     DEFAULT_DEADBAND,
@@ -75,6 +76,7 @@ from .const import (
     DEFAULT_OVERSHOOT,
     DEFAULT_RESEND_INTERVAL,
     DEFAULT_SENSOR_TIMEOUT,
+    DEFAULT_SINGLE_COMMAND,
     SAFETY_TICK,
 )
 
@@ -153,6 +155,9 @@ class RangeThermostat(ClimateEntity, RestoreEntity):
         )
         self._resend_interval = float(
             options.get(CONF_RESEND_INTERVAL, DEFAULT_RESEND_INTERVAL)
+        )
+        self._single_command = bool(
+            options.get(CONF_SINGLE_COMMAND, DEFAULT_SINGLE_COMMAND)
         )
 
     @property
@@ -566,7 +571,7 @@ class RangeThermostat(ClimateEntity, RestoreEntity):
             # Same mode: setpoint adjustments are never blocked by the cooldown.
             await self._async_send(mode, setpoint)
         elif self._resend_due(now):
-            await self._async_send(mode, setpoint)
+            await self._async_send(mode, setpoint, force_mode=True)
 
     def _resend_due(self, now: datetime) -> bool:
         """Return True when the current command should be re-asserted."""
@@ -604,8 +609,21 @@ class RangeThermostat(ClimateEntity, RestoreEntity):
         self._last_commanded_setpoint = None
         self._last_command_at = now
 
-    async def _async_send(self, mode: HVACMode, setpoint: float) -> bool:
-        """Send mode and setpoint as a single service call. Return True on success."""
+    async def _async_send(
+        self, mode: HVACMode, setpoint: float, *, force_mode: bool = False
+    ) -> bool:
+        """Bring the underlying unit to ``mode`` @ ``setpoint``.
+
+        Home Assistant does not dispatch ``async_set_hvac_mode`` when
+        ``hvac_mode`` rides along with ``climate.set_temperature``; it just
+        forwards the kwarg and leaves it to the platform, and most platforms
+        ignore it. So mode and setpoint go as two separate service calls, which
+        every platform understands. ``single_command`` folds them back into one
+        for platforms that do honour it -- notably ESPHome, where a second call
+        means a second IR frame.
+
+        Return True when the unit is now in the requested state.
+        """
         if not self._underlying_available():
             _LOGGER.debug(
                 "%s: %s is unavailable, skipping command",
@@ -613,28 +631,46 @@ class RangeThermostat(ClimateEntity, RestoreEntity):
                 self._climate_entity_id,
             )
             return False
-        try:
-            await self.hass.services.async_call(
-                CLIMATE_DOMAIN,
+
+        send_mode = force_mode or mode is not self._last_commanded_mode
+        now = dt_util.utcnow()
+
+        if send_mode and self._single_command:
+            if not await self._async_call(
                 SERVICE_SET_TEMPERATURE,
-                {
-                    ATTR_ENTITY_ID: self._climate_entity_id,
-                    ATTR_HVAC_MODE: mode,
-                    ATTR_TEMPERATURE: setpoint,
-                },
-                blocking=True,
-                context=self._context,
-            )
-        except HomeAssistantError as err:
-            _LOGGER.error(
-                "%s: failed to command %s to %s @ %s: %s",
+                {ATTR_HVAC_MODE: mode, ATTR_TEMPERATURE: setpoint},
+                mode,
+                setpoint,
+            ):
+                return False
+            self._last_commanded_mode = mode
+            self._last_commanded_setpoint = setpoint
+            self._last_command_at = now
+            _LOGGER.debug(
+                "%s: commanded %s to %s @ %s",
                 self.entity_id,
                 self._climate_entity_id,
                 mode,
                 setpoint,
-                err,
             )
+            return True
+
+        # Setpoint first. A unit briefly left in the old mode at the new
+        # setpoint idles; the old setpoint under the new mode would run the
+        # wrong direction until the second call lands.
+        if not await self._async_call(
+            SERVICE_SET_TEMPERATURE, {ATTR_TEMPERATURE: setpoint}, mode, setpoint
+        ):
             return False
+        self._last_commanded_setpoint = setpoint
+        self._last_command_at = now
+
+        if send_mode:
+            if not await self._async_call(
+                SERVICE_SET_HVAC_MODE, {ATTR_HVAC_MODE: mode}, mode, setpoint
+            ):
+                return False
+            self._last_commanded_mode = mode
 
         _LOGGER.debug(
             "%s: commanded %s to %s @ %s",
@@ -643,9 +679,35 @@ class RangeThermostat(ClimateEntity, RestoreEntity):
             mode,
             setpoint,
         )
-        self._last_commanded_mode = mode
-        self._last_commanded_setpoint = setpoint
-        self._last_command_at = dt_util.utcnow()
+        return True
+
+    async def _async_call(
+        self,
+        service: str,
+        data: dict[str, Any],
+        mode: HVACMode,
+        setpoint: float,
+    ) -> bool:
+        """Call one climate service on the underlying entity."""
+        try:
+            await self.hass.services.async_call(
+                CLIMATE_DOMAIN,
+                service,
+                {ATTR_ENTITY_ID: self._climate_entity_id, **data},
+                blocking=True,
+                context=self._context,
+            )
+        except HomeAssistantError as err:
+            _LOGGER.error(
+                "%s: failed to command %s to %s @ %s via %s: %s",
+                self.entity_id,
+                self._climate_entity_id,
+                mode,
+                setpoint,
+                service,
+                err,
+            )
+            return False
         return True
 
     def _underlying_available(self) -> bool:

--- a/custom_components/range_thermostat/config_flow.py
+++ b/custom_components/range_thermostat/config_flow.py
@@ -22,11 +22,13 @@ from .const import (
     CONF_RESEND_INTERVAL,
     CONF_SENSOR_ENTITY,
     CONF_SENSOR_TIMEOUT,
+    CONF_SINGLE_COMMAND,
     DEFAULT_DEADBAND,
     DEFAULT_MIN_CYCLE_DURATION,
     DEFAULT_OVERSHOOT,
     DEFAULT_RESEND_INTERVAL,
     DEFAULT_SENSOR_TIMEOUT,
+    DEFAULT_SINGLE_COMMAND,
     DOMAIN,
 )
 
@@ -126,6 +128,10 @@ class RangeThermostatOptionsFlow(OptionsFlow):
                     CONF_RESEND_INTERVAL,
                     default=options.get(CONF_RESEND_INTERVAL, DEFAULT_RESEND_INTERVAL),
                 ): _minutes(0, 240),
+                vol.Required(
+                    CONF_SINGLE_COMMAND,
+                    default=options.get(CONF_SINGLE_COMMAND, DEFAULT_SINGLE_COMMAND),
+                ): selector.BooleanSelector(),
             }
         )
         return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/range_thermostat/const.py
+++ b/custom_components/range_thermostat/const.py
@@ -16,12 +16,18 @@ CONF_MIN_CYCLE_DURATION = "min_cycle_duration"
 CONF_OVERSHOOT = "overshoot"
 CONF_SENSOR_TIMEOUT = "sensor_timeout"
 CONF_RESEND_INTERVAL = "resend_interval"
+CONF_SINGLE_COMMAND = "single_command"
 
 DEFAULT_DEADBAND = 1.0
 DEFAULT_MIN_CYCLE_DURATION = 15  # minutes
 DEFAULT_OVERSHOOT = 0.0
 DEFAULT_SENSOR_TIMEOUT = 15  # minutes
 DEFAULT_RESEND_INTERVAL = 0  # minutes, 0 disables re-assertion
+# Home Assistant does not dispatch async_set_hvac_mode when hvac_mode rides
+# along with climate.set_temperature -- each platform has to read it out of the
+# kwargs itself, and most do not. Two separate calls work everywhere, so that is
+# the default; ESPHome-backed IR units can opt into one call (one IR frame).
+DEFAULT_SINGLE_COMMAND = False
 
 # Periodic safety evaluation, independent of sensor updates.
 SAFETY_TICK = timedelta(minutes=5)

--- a/custom_components/range_thermostat/strings.json
+++ b/custom_components/range_thermostat/strings.json
@@ -28,14 +28,16 @@
           "min_cycle_duration": "Minimum cycle duration",
           "overshoot": "Overshoot",
           "sensor_timeout": "Sensor timeout",
-          "resend_interval": "Resend interval"
+          "resend_interval": "Resend interval",
+          "single_command": "Combine mode and setpoint into one command"
         },
         "data_description": {
           "deadband": "How far outside the band the room must drift before a mode change is triggered. Applied symmetrically to both edges.",
           "min_cycle_duration": "Minimum time between mode changes. Setpoint adjustments within the same mode are never delayed.",
           "overshoot": "Pulls the commanded setpoint toward the middle of the band to buy coast time. Clamped at the midpoint.",
           "sensor_timeout": "How long the temperature sensor may go without an update before the thermostat stops issuing commands.",
-          "resend_interval": "Re-send the current command this often to recover from dropped IR transmissions. 0 disables it."
+          "resend_interval": "Re-send the current command this often to recover from dropped IR transmissions. 0 disables it.",
+          "single_command": "Send a mode change as a single climate.set_temperature call carrying hvac_mode, instead of two separate calls. Only enable this if the underlying integration honours hvac_mode inside set_temperature - ESPHome does, and folds it into one IR frame, but most integrations silently ignore it and would never change mode."
         }
       }
     }

--- a/custom_components/range_thermostat/translations/en.json
+++ b/custom_components/range_thermostat/translations/en.json
@@ -28,14 +28,16 @@
           "min_cycle_duration": "Minimum cycle duration",
           "overshoot": "Overshoot",
           "sensor_timeout": "Sensor timeout",
-          "resend_interval": "Resend interval"
+          "resend_interval": "Resend interval",
+          "single_command": "Combine mode and setpoint into one command"
         },
         "data_description": {
           "deadband": "How far outside the band the room must drift before a mode change is triggered. Applied symmetrically to both edges.",
           "min_cycle_duration": "Minimum time between mode changes. Setpoint adjustments within the same mode are never delayed.",
           "overshoot": "Pulls the commanded setpoint toward the middle of the band to buy coast time. Clamped at the midpoint.",
           "sensor_timeout": "How long the temperature sensor may go without an update before the thermostat stops issuing commands.",
-          "resend_interval": "Re-send the current command this often to recover from dropped IR transmissions. 0 disables it."
+          "resend_interval": "Re-send the current command this often to recover from dropped IR transmissions. 0 disables it.",
+          "single_command": "Send a mode change as a single climate.set_temperature call carrying hvac_mode, instead of two separate calls. Only enable this if the underlying integration honours hvac_mode inside set_temperature - ESPHome does, and folds it into one IR frame, but most integrations silently ignore it and would never change mode."
         }
       }
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,8 +52,10 @@ class Command:
 class MockMinisplit(ClimateEntity):
     """A single-setpoint climate entity that records what it is told to do.
 
-    Modelled on an IR-driven unit: optimistic, no feedback, and it honours
-    ``hvac_mode`` passed into ``set_temperature`` the way ESPHome does.
+    Defaults to the common case: a platform that ignores ``hvac_mode`` passed
+    into ``set_temperature``. Home Assistant forwards that kwarg without
+    dispatching ``async_set_hvac_mode``, and most platforms drop it on the
+    floor, so a thermostat that relies on it would never change mode here.
     """
 
     _attr_name = "Minisplit"
@@ -65,6 +67,9 @@ class MockMinisplit(ClimateEntity):
     _attr_min_temp = 60
     _attr_max_temp = 86
     _attr_target_temperature_step = 1
+
+    #: Whether ``async_set_temperature`` acts on a ``hvac_mode`` kwarg.
+    honours_hvac_mode = False
 
     def __init__(self) -> None:
         """Start powered off."""
@@ -78,16 +83,27 @@ class MockMinisplit(ClimateEntity):
         """Return whether the unit is reachable."""
         return self._available
 
+    @property
+    def settled(self) -> Command | None:
+        """The state the unit was driven to, or None if nothing was sent.
+
+        A mode change is normally two service calls, so the individual entries
+        in ``commands`` include a transient. This is the net result.
+        """
+        if not self.commands:
+            return None
+        return Command(self._attr_hvac_mode, self._attr_target_temperature)
+
     def set_available(self, available: bool) -> None:
         """Flip availability and push the new state."""
         self._available = available
         self.async_write_ha_state()
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
-        """Record a setpoint, and a mode when one rides along."""
+        """Record a setpoint, and a mode only if this platform honours one."""
         hvac_mode = kwargs.get("hvac_mode")
         temperature = kwargs.get(ATTR_TEMPERATURE)
-        if hvac_mode is not None:
+        if hvac_mode is not None and self.honours_hvac_mode:
             self._attr_hvac_mode = HVACMode(hvac_mode)
         if temperature is not None:
             self._attr_target_temperature = temperature
@@ -101,6 +117,12 @@ class MockMinisplit(ClimateEntity):
         self.async_write_ha_state()
 
 
+class ESPHomeStyleMinisplit(MockMinisplit):
+    """An IR bridge that folds ``hvac_mode`` into one command, as ESPHome does."""
+
+    honours_hvac_mode = True
+
+
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations):
     """Load custom_components/ during tests."""
@@ -108,9 +130,14 @@ def auto_enable_custom_integrations(enable_custom_integrations):
 
 
 @pytest.fixture
-def minisplit() -> MockMinisplit:
-    """Return the fake underlying unit."""
-    return MockMinisplit()
+def minisplit(request) -> MockMinisplit:
+    """Return the fake underlying unit.
+
+    Parametrize indirectly to swap in a different platform flavour, e.g.
+    ``@pytest.mark.parametrize("minisplit", [ESPHomeStyleMinisplit], indirect=True)``.
+    """
+    cls = getattr(request, "param", MockMinisplit)
+    return cls()
 
 
 @pytest.fixture

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -75,7 +75,7 @@ async def test_1_below_band_commands_heat(
     set_sensor(68.5)
     await hass.async_block_till_done()
 
-    assert minisplit.commands == [Command(HVACMode.HEAT, 70.0)]
+    assert minisplit.settled == Command(HVACMode.HEAT, 70.0)
     state = hass.states.get(THERMOSTAT)
     assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.HEATING
     assert state.attributes[ATTR_COMMANDED_SETPOINT] == 70.0
@@ -115,7 +115,7 @@ async def test_3_above_band_commands_cool(
 
     await advance(hass, freezer, 16, set_sensor, 74.0)
 
-    assert minisplit.commands == [Command(HVACMode.COOL, 72.0)]
+    assert minisplit.settled == Command(HVACMode.COOL, 72.0)
     assert (
         hass.states.get(THERMOSTAT).attributes[ATTR_HVAC_ACTION] == HVACAction.COOLING
     )
@@ -154,7 +154,7 @@ async def test_5_mode_change_after_cooldown(
 
     await advance(hass, freezer, 11, set_sensor, 68.5)
 
-    assert minisplit.commands == [Command(HVACMode.HEAT, 70.0)]
+    assert minisplit.settled == Command(HVACMode.HEAT, 70.0)
     # The flip restarts the cooldown.
     assert (
         hass.states.get(THERMOSTAT).attributes[ATTR_TIME_UNTIL_NEXT_ALLOWED_CHANGE] > 0
@@ -175,7 +175,7 @@ async def test_6_same_mode_setpoint_change_ignores_cooldown(
     # Still well inside the cooldown.
     await set_band(hass, 66, 68)
 
-    assert minisplit.commands == [Command(HVACMode.COOL, 68.0)]
+    assert minisplit.settled == Command(HVACMode.COOL, 68.0)
     assert (
         hass.states.get(THERMOSTAT).attributes[ATTR_TIME_UNTIL_NEXT_ALLOWED_CHANGE] > 0
     )
@@ -259,7 +259,7 @@ async def test_8_restart_restores_band_and_mode(
     assert state.attributes[ATTR_TARGET_TEMP_LOW] == 66.0
     assert state.attributes[ATTR_TARGET_TEMP_HIGH] == 68.0
     # Cooldown is treated as expired, so the first evaluation may command straight away.
-    assert minisplit.commands == [Command(HVACMode.HEAT, 66.0)]
+    assert minisplit.settled == Command(HVACMode.HEAT, 66.0)
 
 
 async def test_9_narrow_band_is_widened(hass, setup_thermostat, caplog):
@@ -292,7 +292,7 @@ async def test_10_identical_evaluations_issue_one_command(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert minisplit.commands == [Command(HVACMode.HEAT, 70.0)]
+    assert minisplit.settled == Command(HVACMode.HEAT, 70.0)
 
 
 async def test_off_is_only_commanded_by_the_user(

--- a/tests/test_behaviour.py
+++ b/tests/test_behaviour.py
@@ -34,10 +34,17 @@ from custom_components.range_thermostat.const import (
     CONF_RESEND_INTERVAL,
     CONF_SENSOR_ENTITY,
     CONF_SENSOR_TIMEOUT,
+    CONF_SINGLE_COMMAND,
     DOMAIN,
 )
 
-from .conftest import CLIMATE_ENTITY, SENSOR_ENTITY, THERMOSTAT, Command
+from .conftest import (
+    CLIMATE_ENTITY,
+    SENSOR_ENTITY,
+    THERMOSTAT,
+    Command,
+    ESPHomeStyleMinisplit,
+)
 from .test_acceptance import NO_SENSOR_TIMEOUT, advance, set_band
 
 
@@ -51,7 +58,7 @@ async def test_overshoot_pulls_the_setpoint_inward(
     set_sensor(68.5)
     await hass.async_block_till_done()
 
-    assert minisplit.commands == [Command(HVACMode.HEAT, 70.5)]
+    assert minisplit.settled == Command(HVACMode.HEAT, 70.5)
 
 
 async def test_overshoot_is_clamped_at_the_midpoint(
@@ -64,7 +71,7 @@ async def test_overshoot_is_clamped_at_the_midpoint(
     set_sensor(74.0)
     await hass.async_block_till_done()
 
-    assert minisplit.commands == [Command(HVACMode.COOL, 71.0)]
+    assert minisplit.settled == Command(HVACMode.COOL, 71.0)
 
 
 async def test_resend_reasserts_the_same_command(
@@ -75,14 +82,17 @@ async def test_resend_reasserts_the_same_command(
     await set_band(hass, 70, 72)
     set_sensor(68.5)
     await hass.async_block_till_done()
-    assert minisplit.commands == [Command(HVACMode.HEAT, 70.0)]
+    assert minisplit.settled == Command(HVACMode.HEAT, 70.0)
 
     await advance(hass, freezer, 5, set_sensor, 68.5)
 
-    assert minisplit.commands == [
+    # The resend re-asserts the mode too, so a dropped IR frame that left the
+    # unit in the wrong mode gets corrected, not just the setpoint.
+    assert minisplit.commands[-2:] == [
         Command(HVACMode.HEAT, 70.0),
-        Command(HVACMode.HEAT, 70.0),
+        Command(HVACMode.HEAT, None),
     ]
+    assert minisplit.settled == Command(HVACMode.HEAT, 70.0)
 
 
 async def test_resend_disabled_by_default(
@@ -119,7 +129,7 @@ async def test_unavailable_minisplit_is_retried(
     set_sensor(68.4)
     await hass.async_block_till_done()
 
-    assert minisplit.commands == [Command(HVACMode.HEAT, 70.0)]
+    assert minisplit.settled == Command(HVACMode.HEAT, 70.0)
 
 
 async def test_options_apply_without_a_restart(
@@ -135,7 +145,7 @@ async def test_options_apply_without_a_restart(
     hass.config_entries.async_update_entry(entry, options={CONF_DEADBAND: 0.1})
     await hass.async_block_till_done()
 
-    assert minisplit.commands == [Command(HVACMode.HEAT, 70.0)]
+    assert minisplit.settled == Command(HVACMode.HEAT, 70.0)
 
 
 async def test_options_update_keeps_the_cooldown(
@@ -174,7 +184,7 @@ async def test_turning_back_on_can_act_immediately(
         )
         await hass.async_block_till_done()
 
-    assert minisplit.commands[-1] == Command(HVACMode.HEAT, 70.0)
+    assert minisplit.settled == Command(HVACMode.HEAT, 70.0)
     assert (
         hass.states.get(THERMOSTAT).attributes[ATTR_HVAC_ACTION] == HVACAction.HEATING
     )
@@ -217,7 +227,7 @@ async def test_celsius_sensor_is_converted(
     )
     await hass.async_block_till_done()
 
-    assert minisplit.commands == [Command(HVACMode.HEAT, 70.0)]
+    assert minisplit.settled == Command(HVACMode.HEAT, 70.0)
     assert hass.states.get(THERMOSTAT).attributes["current_temperature"] == 68
 
 
@@ -357,3 +367,79 @@ async def test_repeated_identical_readings_are_not_stale(
         await hass.async_block_till_done()
 
     assert hass.states.get(THERMOSTAT).attributes["sensor_stale"] is False
+
+
+# ----------------------------------------------------------------------
+# How a mode change is put on the wire
+# ----------------------------------------------------------------------
+
+
+async def test_mode_change_is_two_calls_by_default(
+    hass, setup_thermostat, minisplit, set_sensor
+):
+    """Setpoint then mode, so it works on platforms that ignore hvac_mode.
+
+    Home Assistant forwards ``hvac_mode`` into ``async_set_temperature``
+    without dispatching ``async_set_hvac_mode``, and most climate platforms
+    ignore the kwarg. The default mock is one of those, so a single combined
+    call would leave the unit off.
+    """
+    await setup_thermostat(70.0)
+    await set_band(hass, 70, 72)
+    set_sensor(68.5)
+    await hass.async_block_till_done()
+
+    # Setpoint lands first, while the unit is still off; then the mode.
+    assert minisplit.commands == [
+        Command(HVACMode.OFF, 70.0),
+        Command(HVACMode.HEAT, None),
+    ]
+    assert minisplit.settled == Command(HVACMode.HEAT, 70.0)
+
+
+async def test_setpoint_change_within_a_mode_is_one_call(
+    hass, setup_thermostat, minisplit, set_sensor
+):
+    """No mode flip means no set_hvac_mode call."""
+    await setup_thermostat(70.0)
+    await set_band(hass, 70, 72)
+    set_sensor(68.5)
+    await hass.async_block_till_done()
+    minisplit.commands.clear()
+
+    await set_band(hass, 66, 72)
+    await hass.async_block_till_done()
+
+    assert minisplit.commands == [Command(HVACMode.HEAT, 66.0)]
+
+
+@pytest.mark.parametrize("minisplit", [ESPHomeStyleMinisplit], indirect=True)
+async def test_single_command_option_sends_one_call(
+    hass, setup_thermostat, minisplit, set_sensor
+):
+    """ESPHome honours hvac_mode inside set_temperature -- one call, one IR frame."""
+    await setup_thermostat(70.0, **{CONF_SINGLE_COMMAND: True})
+    await set_band(hass, 70, 72)
+    set_sensor(68.5)
+    await hass.async_block_till_done()
+
+    assert minisplit.commands == [Command(HVACMode.HEAT, 70.0)]
+    assert minisplit.settled == Command(HVACMode.HEAT, 70.0)
+
+
+async def test_single_command_would_strand_a_platform_that_ignores_hvac_mode(
+    hass, setup_thermostat, minisplit, set_sensor
+):
+    """Why two calls is the default.
+
+    Turning the option on against a platform that drops ``hvac_mode`` gets the
+    setpoint applied and the mode silently ignored, so the unit never starts
+    heating. This is the failure mode the default avoids.
+    """
+    await setup_thermostat(70.0, **{CONF_SINGLE_COMMAND: True})
+    await set_band(hass, 70, 72)
+    set_sensor(68.5)
+    await hass.async_block_till_done()
+
+    assert minisplit.target_temperature == 70.0
+    assert minisplit.hvac_mode == HVACMode.OFF


### PR DESCRIPTION
#8 got merged while I was working on this, so this is a follow-up rather than a change to that PR.

## The bug

The mode change relied on `hvac_mode` riding along with `climate.set_temperature`. That works on ESPHome, which is what I checked against and what the tests modelled - but it does not work in general, and the immediate trigger for this PR is that ESPHome isn't set up yet, so the integration would have been driving a wifi `climate` entity instead.

Home Assistant core does not dispatch `async_set_hvac_mode` when `hvac_mode` is passed to `set_temperature`. `async_service_temperature_set` in `components/climate/__init__.py` just copies the service data into kwargs and calls `entity.async_set_temperature(**kwargs)`. It's up to each platform to read `ATTR_HVAC_MODE` back out, and most don't - 29 of the 108 climate platforms in core even reference the constant.

On the other 79 the setpoint would have applied and the mode would have been silently dropped, so the minisplit would never actually start heating or cooling. Every command would look like it succeeded.

`gree` happens to be one of the 29 that does handle it, so if that's the integration behind `climate.minisplit` the old code would have worked by luck. I'd rather not depend on that.

## The fix

A mode change is now two service calls: `climate.set_temperature`, then `climate.set_hvac_mode`. Setpoint-only changes are still a single call, so the extra traffic only happens on an actual flip. Resends now re-assert the mode too, so a dropped frame that left the unit in the wrong mode gets corrected rather than just the setpoint.

Setpoint goes first deliberately. A unit briefly left in the old mode at the new setpoint idles - if we're flipping heat to cool because the room is at 73, setting the heat target to 72 first does nothing. Mode-first would command cool at the old *heat* setpoint of 70, running the wrong direction until the second call lands.

Added a `single_command` option (default off) that folds a mode change back into one call. ESPHome does honour `hvac_mode` inside `set_temperature` and turns it into a single IR frame, so anyone on that setup can halve the IR traffic and the beeping. It's opt-in because getting it wrong fails silently.

## How I verified it

The default `MockMinisplit` now ignores `hvac_mode` inside `set_temperature`, which is the common case and what the old code got wrong. A new `ESPHomeStyleMinisplit` honours it and covers the opt-in path. 34 tests pass.

The load-bearing check: flipping `DEFAULT_SINGLE_COMMAND` back to `True` - which is exactly the old behaviour - fails 17 of the 34 tests. So the suite genuinely catches this now, where before it was blind to it by construction.

Four new tests pin the wire format directly:

- `test_mode_change_is_two_calls_by_default` - asserts the exact sequence, setpoint then mode.
- `test_setpoint_change_within_a_mode_is_one_call` - no needless second call.
- `test_single_command_option_sends_one_call` - the ESPHome path.
- `test_single_command_would_strand_a_platform_that_ignores_hvac_mode` - documents the failure mode: setpoint applied, unit still off.

Most existing assertions moved from `minisplit.commands == [...]` to a new `minisplit.settled`, since a mode change is now two calls and the intermediate state is a real transient. `settled` returns `None` when nothing was sent, so it still catches a missing command.

## What I did NOT verify

Still no real hardware. The claim that `gree` handles `ATTR_HVAC_MODE` comes from reading `components/gree/climate.py`, not from watching a unit. That doesn't matter much now - the point of this change is that it no longer depends on which integration is underneath.
